### PR TITLE
Use \S in regexp instead of [^\s]

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ export function get_includes(data: string) {
   let set: Set<string> = new Set();
   let match: RegExpExecArray | null;
 
-  let re = /(-I)([^\s]+)+/g;
+  let re = /(-I)(\S+)+/g;
   while ((match = re.exec(data.toString()))) {
     let real_path = match[2].toString();
     set.add(real_path);
@@ -79,7 +79,7 @@ function get_defines(riot_build_h_file: string) {
   var out = shell.cat(real_path);
   //console.log(out);
   let lines = out.split('\n');
-  let re = /^(#define[\s]+)([^\s]+)[\s]+([^\s]+)$/;
+  let re = /^(#define[\s]+)(\S+)[\s]+(\S+)$/;
 
   for (let line of lines) {
     if ((match = re.exec(line))) {
@@ -100,7 +100,7 @@ function get_system_includes() {
   // https://stackoverflow.com/questions/17939930/finding-out-what-the-gcc-include-path-is
   let out = shell.exec('echo | ' + compiler + ' -E -Wp,-v -xc -').stderr;
   let lines = out.split(/\r?\n/);
-  let re = /^(\s)+([^\s]+)+$/;
+  let re = /^(\s)+(\S+)+$/;
 
   for (let line of lines) {
     if ((match = re.exec(line))) {


### PR DESCRIPTION
This is just a minor issue. Regexp has `\S` defined as (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes):

> Matches a single character other than white space. Equivalent to [^ \f\n\r\t\v\u00a0\u1680\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]

This commit changes all [^\s] => \S